### PR TITLE
Concat <?php tags according to the code entered

### DIFF
--- a/ob-php.el
+++ b/ob-php.el
@@ -40,7 +40,9 @@
 (defun org-babel-execute:php (body params)
   "Orgmode Babel PHP evaluate function for `BODY' with `PARAMS'."
   (let* ((cmd (concat org-babel-php-command " " org-babel-php-command-options))
-         (body (concat "<?php\n" body "\n?>")))
+         (code (if (string-match-p "<\\?\\(?:php\\|=\\)\\_>" body)
+                   body
+                 (concat "<?php\n\n" body))))
     (org-babel-eval cmd body)))
 
 ;;;###autoload


### PR DESCRIPTION
It's very convenient because we can omit PHP tags from PHP code snippets.

----------

`test.org`

```org
* Examples
** PHP Code without PHP tag
*** A expression-statement
#+BEGIN_SRC php
echo PHP_VERSION;
#+END_SRC

#+RESULTS:
: 7.4.25
*** Code with strict_types declaration
#+BEGIN_SRC php
declare(strict_types=0);

var_dump(to_int(true));
var_dump(to_int("0"));

function to_int($v): int
{
    return $v;
}
#+END_SRC

#+RESULTS:
: int(1)
: int(0)

** PHP code with HTML
#+BEGIN_SRC php
<p><?= date('Y-m-d H:i:s') ?></p>
#+END_SRC

#+RESULTS:
: <p>2021-11-08 13:29:48</p>
```